### PR TITLE
use cwl-specific logger, rather than the root logger

### DIFF
--- a/cwl/cwl_eval.py
+++ b/cwl/cwl_eval.py
@@ -99,11 +99,13 @@ def parse_args():
 def main(results_file, gain_file, cost_file=None, metrics_file=None, bib_file=None, col_names=False,
          residuals=False, max_gain=1.0, min_gain=0.0, max_cost=1.0, min_cost=1.0, max_n=1000):
   
-    logging.basicConfig(filename='cwl.log', level=logging.DEBUG)
-    logging.info("Processing: {} using gain: {} and costs: {}".format(results_file, gain_file, cost_file))
-    logging.info("Max Gain: {} Max Cost: {} Min Cost: {} Max N: {}".format(max_gain, max_cost, min_cost, max_n))
+    logger = logging.getLogger('cwl')
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(logging.FileHandler('cwl.log'))
+    logger.info("Processing: {} using gain: {} and costs: {}".format(results_file, gain_file, cost_file))
+    logger.info("Max Gain: {} Max Cost: {} Min Cost: {} Max N: {}".format(max_gain, max_cost, min_cost, max_n))
     if args.residuals:
-        logging.info("Residuals are being computed assuming max gain is: {}".format(max_gain))
+        logger.info("Residuals are being computed assuming max gain is: {}".format(max_gain))
     qrh = TrecQrelHandler(gain_file)
     qrh.validate_gains(min_gain=min_gain, max_gain=max_gain)
     costs = None

--- a/cwl/ruler/measures/cwl_metrics.py
+++ b/cwl/ruler/measures/cwl_metrics.py
@@ -2,7 +2,7 @@ import math
 import numpy as np
 import logging
 
-logging.basicConfig(filename='cwl.log', level=logging.DEBUG)
+logger = logging.getLogger('cwl')
 
 class CWLMetric(object):
 
@@ -47,11 +47,11 @@ class CWLMetric(object):
         :return: returns the L vector probabilities
         """
         cvec = self.c_vector(ranking, worse_case)
-        logging.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "cvec", cvec[0:11]))
+        logger.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "cvec", cvec[0:11]))
         cshift = np.append(np.array([1.0]), cvec[0:-1])
         lvec = np.cumprod(cshift)
         lvec = np.multiply(lvec, (np.subtract(np.ones(len(cvec)), cvec)))
-        logging.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "lvec", lvec[0:11]))
+        logger.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "lvec", lvec[0:11]))
         return lvec
 
     def w_vector(self, ranking, worse_case=True):
@@ -69,7 +69,7 @@ class CWLMetric(object):
         w1 = np.divide(1.0, np.sum(cvec_prod))
         w_tail = np.multiply(cvec_prod[1:len(cvec_prod)], w1)
         wvec = np.append(w1, w_tail)
-        logging.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "wvec", wvec[0:11]))
+        logger.debug("{0} {1} {2} {3}".format(ranking.topic_id, self.name(), "wvec", wvec[0:11]))
         return wvec
 
     def measure(self, ranking):


### PR DESCRIPTION
Makes it possible to configure logging from cwl in other software that uses this package.